### PR TITLE
fix so you can have databases with space in name

### DIFF
--- a/roskarl/env.py
+++ b/roskarl/env.py
@@ -791,7 +791,7 @@ def env_var_dsn(name: str, default: DSN | None = None) -> DSN:
         password = unquote(credentials[colon_pos + 1 :])
         database_parts = host_part.split("/", 1)
         host_and_port = database_parts[0]
-        database = database_parts[1] if len(database_parts) > 1 else None
+        database = unquote(database_parts[1]) if len(database_parts) > 1 else None
         if ":" in host_and_port:
             hostname, port_str = host_and_port.rsplit(":", 1)
             port = int(port_str)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -332,6 +332,44 @@ class TestEnvVarUtils(unittest.TestCase):
             "host=localhost user=user password=pass port=5432 dbname=mydb",
         )
 
+    def test_dsn_libpq_string_no_port(self):
+        dsn = DSN(
+            protocol="postgresql",
+            username="user",
+            password="pass",
+            hostname="localhost",
+            database="mydb",
+        )
+        self.assertEqual(
+            dsn.libpq_string,
+            "host=localhost user=user password=pass dbname=mydb",
+        )
+
+    def test_dsn_libpq_string_no_database(self):
+        dsn = DSN(
+            protocol="postgresql",
+            username="user",
+            password="pass",
+            hostname="localhost",
+            port=5432,
+        )
+        self.assertEqual(
+            dsn.libpq_string,
+            "host=localhost user=user password=pass port=5432",
+        )
+
+    def test_dsn_libpq_string_no_port_no_database(self):
+        dsn = DSN(
+            protocol="postgresql",
+            username="user",
+            password="pass",
+            hostname="localhost",
+        )
+        self.assertEqual(
+            dsn.libpq_string,
+            "host=localhost user=user password=pass",
+        )
+
     def test_dsn_build_mssql_string(self):
         dsn = DSN(
             protocol="mssql",
@@ -341,14 +379,38 @@ class TestEnvVarUtils(unittest.TestCase):
             port=1433,
             database="mydb",
         )
-        result = dsn.build_mssql_string()
-        self.assertIn("DRIVER={ODBC Driver 18 for SQL Server}", result)
-        self.assertIn("SERVER=db.example.com,1433", result)
-        self.assertIn("DATABASE=mydb", result)
-        self.assertIn("UID=sa", result)
-        self.assertIn("PWD=pw", result)
-        self.assertIn("Encrypt=yes", result)
-        self.assertIn("TrustServerCertificate=yes", result)
+        self.assertEqual(
+            dsn.build_mssql_string(),
+            "DRIVER={ODBC Driver 18 for SQL Server};SERVER=db.example.com,1433;DATABASE=mydb;UID=sa;PWD=pw;Encrypt=yes;TrustServerCertificate=yes",
+        )
+
+    def test_dsn_build_mssql_string_no_encrypt(self):
+        dsn = DSN(
+            protocol="mssql",
+            username="sa",
+            password="pw",
+            hostname="db.example.com",
+            port=1433,
+            database="mydb",
+        )
+        self.assertEqual(
+            dsn.build_mssql_string(encrypt=False, trust_server_certificate=False),
+            "DRIVER={ODBC Driver 18 for SQL Server};SERVER=db.example.com,1433;DATABASE=mydb;UID=sa;PWD=pw;Encrypt=no;TrustServerCertificate=no",
+        )
+
+    def test_dsn_build_mssql_string_custom_driver(self):
+        dsn = DSN(
+            protocol="mssql",
+            username="sa",
+            password="pw",
+            hostname="db.example.com",
+            port=1433,
+            database="mydb",
+        )
+        self.assertEqual(
+            dsn.build_mssql_string(driver="ODBC Driver 17 for SQL Server"),
+            "DRIVER={ODBC Driver 17 for SQL Server};SERVER=db.example.com,1433;DATABASE=mydb;UID=sa;PWD=pw;Encrypt=yes;TrustServerCertificate=yes",
+        )
 
     def test_dsn_build_mssql_string_requires_port(self):
         dsn = DSN(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -720,5 +720,45 @@ class TestEnvVarDuration(unittest.TestCase):
         self.assertEqual(env_var_duration("D", default=fallback), fallback)
 
 
+class TestDSNDatabaseNameWithSpaces(unittest.TestCase):
+    def setUp(self):
+        self.original_environ = os.environ.copy()
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_environ)
+
+    def test_percent_encoded_space(self):
+        os.environ["TEST_DSN"] = "mssql://user:pass@host:1433/SDWH%20RIS%20Datamodel"
+        result = env_var_dsn("TEST_DSN")
+        self.assertEqual(result.database, "SDWH RIS Datamodel")
+
+    def test_literal_space_in_database(self):
+        os.environ["TEST_DSN"] = "mssql://user:pass@host:1433/SDWH RIS Datamodel"
+        result = env_var_dsn("TEST_DSN")
+        self.assertEqual(result.database, "SDWH RIS Datamodel")
+
+    def test_multiple_spaces_percent_encoded(self):
+        os.environ["TEST_DSN"] = "mssql://user:pass@host:1433/My%20Database%20Name"
+        result = env_var_dsn("TEST_DSN")
+        self.assertEqual(result.database, "My Database Name")
+
+    def test_no_space_database_unaffected(self):
+        os.environ["TEST_DSN"] = "mssql://user:pass@host:1433/SimpleDB"
+        result = env_var_dsn("TEST_DSN")
+        self.assertEqual(result.database, "SimpleDB")
+
+    def test_mssql_string_with_spaced_database(self):
+        os.environ["TEST_DSN"] = "mssql://sa:pw@db.example.com:1433/SDWH%20RIS%20Datamodel"
+        result = env_var_dsn("TEST_DSN")
+        mssql = result.build_mssql_string()
+        self.assertIn("DATABASE=SDWH RIS Datamodel", mssql)
+
+    def test_connection_string_contains_decoded_database(self):
+        os.environ["TEST_DSN"] = "mssql://user:pass@host:1433/SDWH%20RIS%20Datamodel"
+        result = env_var_dsn("TEST_DSN")
+        self.assertIn("SDWH RIS Datamodel", result.connection_string)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,7 @@ wheels = [
 
 [[package]]
 name = "roskarl"
-version = "3.1.25"
+version = "3.1.26"
 source = { virtual = "." }
 dependencies = [
     { name = "python-icron" },


### PR DESCRIPTION
nu ska man kunna skriva exempelvis SDWH%20RIS%20Datamodel i sin secret och det ska parsas korrekt